### PR TITLE
test: adjust CrosswordPage tests

### DIFF
--- a/test/crossword/view/crossword_page_test.dart
+++ b/test/crossword/view/crossword_page_test.dart
@@ -15,27 +15,17 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../helpers/helpers.dart';
 
-class _MockCrosswordBloc extends Mock implements CrosswordBloc {}
+class _MockCrosswordBloc extends MockBloc<CrosswordEvent, CrosswordState>
+    implements CrosswordBloc {}
 
 class _FakeBoardSection extends Fake implements BoardSection {
   @override
   List<Word> get words => [];
 }
 
-extension on WidgetTester {
-  Future<void> pumpCrosswordView(CrosswordBloc bloc) {
-    return pumpApp(
-      BlocProvider.value(
-        value: bloc,
-        child: CrosswordView(),
-      ),
-    );
-  }
-}
-
 void main() {
-  group('CrosswordPage', () {
-    testWidgets('renders CrosswordView', (tester) async {
+  group('$CrosswordPage', () {
+    testWidgets('renders $CrosswordView', (tester) async {
       await tester.pumpRoute(CrosswordPage.route());
       await tester.pump();
 
@@ -43,47 +33,33 @@ void main() {
     });
   });
 
-  group('CrosswordView', () {
-    late CrosswordBloc bloc;
+  group('$CrosswordView', () {
+    late CrosswordBloc crosswordBloc;
 
     setUp(() {
-      bloc = _MockCrosswordBloc();
-
-      whenListen(
-        bloc,
-        Stream.fromIterable(const <CrosswordState>[]),
-        initialState: const CrosswordState(),
-      );
+      crosswordBloc = _MockCrosswordBloc();
     });
 
-    testWidgets('renders IoAppBar', (tester) async {
-      when(() => bloc.state).thenReturn(const CrosswordState());
-
-      await tester.pumpCrosswordView(bloc);
+    testWidgets('renders $IoAppBar', (tester) async {
+      await tester.pumpSubject(CrosswordView());
       expect(find.byType(IoAppBar), findsOneWidget);
     });
 
     testWidgets('renders $MuteButton', (tester) async {
-      when(() => bloc.state).thenReturn(CrosswordState());
-
-      await tester.pumpCrosswordView(bloc);
+      await tester.pumpSubject(CrosswordView());
 
       expect(find.byType(MuteButton), findsOneWidget);
     });
 
     testWidgets('renders $EndDrawerButton', (tester) async {
-      when(() => bloc.state).thenReturn(CrosswordState());
-
-      await tester.pumpCrosswordView(bloc);
+      await tester.pumpSubject(CrosswordView());
 
       expect(find.byType(EndDrawerButton), findsOneWidget);
     });
 
     testWidgets('opens $CrosswordDrawer when $EndDrawerButton is tapped',
         (tester) async {
-      when(() => bloc.state).thenReturn(CrosswordState());
-
-      await tester.pumpCrosswordView(bloc);
+      await tester.pumpSubject(CrosswordView());
 
       await tester.tap(find.byType(EndDrawerButton));
 
@@ -93,30 +69,31 @@ void main() {
     });
 
     testWidgets(
-        'renders CircularProgressIndicator with ${CrosswordStatus.initial}',
+        'renders $CircularProgressIndicator with ${CrosswordStatus.initial}',
         (tester) async {
-      when(() => bloc.state).thenReturn(const CrosswordState());
-
-      await tester.pumpCrosswordView(bloc);
+      await tester.pumpSubject(CrosswordView());
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
 
     testWidgets('renders $ErrorView with ${CrosswordStatus.failure}',
         (tester) async {
-      when(() => bloc.state).thenReturn(
+      when(() => crosswordBloc.state).thenReturn(
         const CrosswordState(
           status: CrosswordStatus.failure,
         ),
       );
 
-      await tester.pumpCrosswordView(bloc);
+      await tester.pumpSubject(
+        CrosswordView(),
+        crosswordBloc: crosswordBloc,
+      );
 
       expect(find.byType(ErrorView), findsOneWidget);
     });
 
     testWidgets('renders game with ${CrosswordStatus.success}', (tester) async {
-      when(() => bloc.state).thenReturn(
+      when(() => crosswordBloc.state).thenReturn(
         CrosswordState(
           status: CrosswordStatus.success,
           sectionSize: 40,
@@ -126,16 +103,20 @@ void main() {
         ),
       );
 
-      await tester.pumpCrosswordView(bloc);
+      await tester.pumpSubject(
+        CrosswordView(),
+        crosswordBloc: crosswordBloc,
+      );
 
       expect(find.byType(GameWidget<CrosswordGame>), findsOneWidget);
     });
 
     testWidgets(
-      'renders WordFocusedDesktopPage when is loaded with desktop size',
+      'renders $WordFocusedDesktopPage when is loaded with desktop size',
       (tester) async {
         tester.setDisplaySize(Size(IoCrosswordBreakpoints.medium, 800));
-        when(() => bloc.state).thenReturn(
+
+        when(() => crosswordBloc.state).thenReturn(
           CrosswordState(
             status: CrosswordStatus.success,
             sectionSize: 40,
@@ -145,17 +126,21 @@ void main() {
           ),
         );
 
-        await tester.pumpCrosswordView(bloc);
+        await tester.pumpSubject(
+          CrosswordView(),
+          crosswordBloc: crosswordBloc,
+        );
 
         expect(find.byType(WordFocusedDesktopPage), findsOneWidget);
       },
     );
 
     testWidgets(
-      'does not render WordFocusedDesktopPage when is loaded with mobile size',
+      'does not render $WordFocusedDesktopPage when is loaded with mobile size',
       (tester) async {
         tester.setDisplaySize(Size(IoCrosswordBreakpoints.medium - 1, 800));
-        when(() => bloc.state).thenReturn(
+
+        when(() => crosswordBloc.state).thenReturn(
           CrosswordState(
             status: CrosswordStatus.success,
             sectionSize: 40,
@@ -165,17 +150,21 @@ void main() {
           ),
         );
 
-        await tester.pumpCrosswordView(bloc);
+        await tester.pumpSubject(
+          CrosswordView(),
+          crosswordBloc: crosswordBloc,
+        );
 
         expect(find.byType(WordFocusedDesktopPage), findsNothing);
       },
     );
 
     testWidgets(
-      'renders WordFocusedMobilePage when game is loaded with mobile size',
+      'renders $WordFocusedMobilePage when game is loaded with mobile size',
       (tester) async {
         tester.setDisplaySize(Size(IoCrosswordBreakpoints.medium - 1, 800));
-        when(() => bloc.state).thenReturn(
+
+        when(() => crosswordBloc.state).thenReturn(
           CrosswordState(
             status: CrosswordStatus.success,
             sectionSize: 40,
@@ -185,18 +174,22 @@ void main() {
           ),
         );
 
-        await tester.pumpCrosswordView(bloc);
+        await tester.pumpSubject(
+          CrosswordView(),
+          crosswordBloc: crosswordBloc,
+        );
 
         expect(find.byType(WordFocusedMobilePage), findsOneWidget);
       },
     );
 
     testWidgets(
-      'does not render WordFocusedMobilePage when game is loaded with '
+      'does not render $WordFocusedMobilePage when game is loaded with '
       'desktop size',
       (tester) async {
         tester.setDisplaySize(Size(IoCrosswordBreakpoints.medium, 800));
-        when(() => bloc.state).thenReturn(
+
+        when(() => crosswordBloc.state).thenReturn(
           CrosswordState(
             status: CrosswordStatus.success,
             sectionSize: 40,
@@ -206,7 +199,10 @@ void main() {
           ),
         );
 
-        await tester.pumpCrosswordView(bloc);
+        await tester.pumpSubject(
+          CrosswordView(),
+          crosswordBloc: crosswordBloc,
+        );
 
         expect(find.byType(WordFocusedMobilePage), findsNothing);
       },
@@ -215,14 +211,17 @@ void main() {
     testWidgets(
       'can zoom in',
       (tester) async {
-        when(() => bloc.state).thenReturn(
+        when(() => crosswordBloc.state).thenReturn(
           CrosswordState(
             status: CrosswordStatus.success,
             sectionSize: 40,
           ),
         );
 
-        await tester.pumpCrosswordView(bloc);
+        await tester.pumpSubject(
+          CrosswordView(),
+          crosswordBloc: crosswordBloc,
+        );
 
         final crosswordViewState = tester.state<LoadedBoardViewState>(
           find.byType(LoadedBoardView),
@@ -242,14 +241,18 @@ void main() {
     testWidgets(
       'can zoom out',
       (tester) async {
-        when(() => bloc.state).thenReturn(
+        when(() => crosswordBloc.state).thenReturn(
           CrosswordState(
             status: CrosswordStatus.success,
             sectionSize: 40,
           ),
         );
 
-        await tester.pumpCrosswordView(bloc);
+        await tester.pumpSubject(
+          CrosswordView(),
+          crosswordBloc: crosswordBloc,
+        );
+
         final crosswordViewState = tester.state<LoadedBoardViewState>(
           find.byType(LoadedBoardView),
         );
@@ -265,4 +268,23 @@ void main() {
       timeout: const Timeout(Duration(seconds: 30)),
     );
   });
+}
+
+extension on WidgetTester {
+  Future<void> pumpSubject(
+    Widget child, {
+    CrosswordBloc? crosswordBloc,
+  }) {
+    final bloc = crosswordBloc ?? _MockCrosswordBloc();
+    if (crosswordBloc == null) {
+      when(() => bloc.state).thenReturn(const CrosswordState());
+    }
+
+    return pumpApp(
+      BlocProvider.value(
+        value: bloc,
+        child: child,
+      ),
+    );
+  }
 }


### PR DESCRIPTION
## Description

Adjust the `CrosswordPage` tests to simplify providing the `WordSelectionBloc` into the page (to be provided in a follow-up Pull Request).

Changes:
- MockCrosswordBloc now extends MockBloc
- Member `bloc` renamed to `crosswordBloc`
- Used `$` over hardcoded string in test names to simplify renaming
- Updated method to pump the view with an optional `crosswordBloc` argument (previously un-named and required)

## Screenshots/Video
Not applicable.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
<!--- Input the Monday.com Item IDs for features addressed in the PR -->
