### PR TITLE
feat: include empty WordSelection status

### DIFF
--- a/lib/word_selection/bloc/word_selection_bloc.dart
+++ b/lib/word_selection/bloc/word_selection_bloc.dart
@@ -7,6 +7,7 @@ part 'word_selection_state.dart';
 class WordSelectionBloc extends Bloc<WordSelectionEvent, WordSelectionState> {
   WordSelectionBloc() : super(const WordSelectionState.initial()) {
     on<WordSelected>(_onWordSelected);
+    on<WordUnselected>(_onWordUnselected);
     on<WordSolveRequested>(_onWordSolveRequested);
     on<WordFocusedSuccessRequested>(_onWordFocusedSuccessRequested);
     on<WordSolveAttempted>(_onWordAttemptRequested);
@@ -21,6 +22,15 @@ class WordSelectionBloc extends Bloc<WordSelectionEvent, WordSelectionState> {
         status: WordSelectionStatus.preSolving,
         wordIdentifier: event.wordIdentifier,
       ),
+    );
+  }
+
+  void _onWordUnselected(
+    WordUnselected event,
+    Emitter<WordSelectionState> emit,
+  ) {
+    emit(
+      const WordSelectionState.initial(),
     );
   }
 

--- a/lib/word_selection/bloc/word_selection_event.dart
+++ b/lib/word_selection/bloc/word_selection_event.dart
@@ -4,7 +4,7 @@ sealed class WordSelectionEvent extends Equatable {
   const WordSelectionEvent();
 }
 
-/// {@template word_selected_event}
+/// {@template word_selected}
 /// The user has selected a word.
 ///
 /// The user is yet to decide if they want to solve the word or not.
@@ -19,6 +19,18 @@ class WordSelected extends WordSelectionEvent {
 
   @override
   List<Object> get props => [wordIdentifier];
+}
+
+/// {@template word_unselected}
+/// The user has unselected a word.
+///
+/// This means that the user is no longer interested in solving the word.
+/// {@endtemplate}
+class WordUnselected extends WordSelectionEvent {
+  const WordUnselected();
+
+  @override
+  List<Object> get props => [];
 }
 
 /// {@template word_solve_requested}

--- a/lib/word_selection/bloc/word_selection_state.dart
+++ b/lib/word_selection/bloc/word_selection_state.dart
@@ -1,6 +1,9 @@
 part of 'word_selection_bloc.dart';
 
 enum WordSelectionStatus {
+  /// No word has been selected by the user.
+  empty,
+
   /// The word has not yet been solved, but it is being considered
   /// by the user.
   preSolving,
@@ -34,7 +37,7 @@ class WordSelectionState extends Equatable {
   });
 
   const WordSelectionState.initial()
-      : status = WordSelectionStatus.preSolving,
+      : status = WordSelectionStatus.empty,
         wordIdentifier = null,
         wordPoints = null;
 

--- a/lib/word_selection/view/word_selection_view.dart
+++ b/lib/word_selection/view/word_selection_view.dart
@@ -102,6 +102,7 @@ class _WordSelectionBody extends StatelessWidget {
             WordSolvingView(selectedWord: selectedWord),
           WordSelectionStatus.solved =>
             WordSuccessView(selectedWord: selectedWord),
+          WordSelectionStatus.empty => const SizedBox.shrink(),
         };
         // coverage:ignore-end
         return view;

--- a/lib/word_selection/view/word_success_view.dart
+++ b/lib/word_selection/view/word_success_view.dart
@@ -6,7 +6,8 @@ import 'package:io_crossword/crossword/crossword.dart';
 import 'package:io_crossword/extensions/extensions.dart';
 import 'package:io_crossword/l10n/l10n.dart';
 import 'package:io_crossword/welcome/welcome.dart';
-import 'package:io_crossword/word_selection/word_selection.dart';
+import 'package:io_crossword/word_selection/word_selection.dart'
+    hide WordUnselected;
 import 'package:io_crossword_ui/io_crossword_ui.dart';
 
 /// {@template word_success_view}

--- a/test/word_focused/bloc/word_selection_bloc_test.dart
+++ b/test/word_focused/bloc/word_selection_bloc_test.dart
@@ -26,6 +26,19 @@ void main() {
       );
     });
 
+    group('$WordUnselected', () {
+      blocTest<WordSelectionBloc, WordSelectionState>(
+        'emits initial state',
+        build: WordSelectionBloc.new,
+        seed: () => WordSelectionState(
+          status: WordSelectionStatus.preSolving,
+          wordIdentifier: '1',
+        ),
+        act: (bloc) => bloc.add(WordUnselected()),
+        expect: () => <WordSelectionState>[WordSelectionState.initial()],
+      );
+    });
+
     group('$WordSolveRequested', () {
       blocTest<WordSelectionBloc, WordSelectionState>(
         'does nothing if there is no word identifier',

--- a/test/word_focused/bloc/word_selection_event_test.dart
+++ b/test/word_focused/bloc/word_selection_event_test.dart
@@ -13,6 +13,15 @@ void main() {
     });
   });
 
+  group('$WordUnselected', () {
+    test('supports equality', () {
+      expect(
+        WordUnselected(),
+        equals(WordUnselected()),
+      );
+    });
+  });
+
   group('$WordSolveRequested', () {
     test('supports equality', () {
       expect(

--- a/test/word_focused/bloc/word_selection_state_test.dart
+++ b/test/word_focused/bloc/word_selection_state_test.dart
@@ -8,7 +8,7 @@ void main() {
     test('.initial initializes correctly', () {
       final state = WordSelectionState.initial();
 
-      expect(state.status, WordSelectionStatus.preSolving);
+      expect(state.status, WordSelectionStatus.empty);
       expect(state.wordIdentifier, isNull);
       expect(state.wordPoints, isNull);
     });

--- a/test/word_focused/view/word_success_view_test.dart
+++ b/test/word_focused/view/word_success_view_test.dart
@@ -7,7 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:game_domain/game_domain.dart';
 import 'package:io_crossword/crossword/crossword.dart';
 import 'package:io_crossword/l10n/l10n.dart';
-import 'package:io_crossword/word_selection/word_selection.dart';
+import 'package:io_crossword/word_selection/word_selection.dart'
+    hide WordUnselected;
 import 'package:io_crossword_ui/io_crossword_ui.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';

--- a/test/word_selection/widgets/close_word_selection_icon_button_test.dart
+++ b/test/word_selection/widgets/close_word_selection_icon_button_test.dart
@@ -1,7 +1,8 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:io_crossword/crossword/crossword.dart';
-import 'package:io_crossword/word_selection/word_selection.dart';
+import 'package:io_crossword/word_selection/word_selection.dart'
+    hide WordUnselected;
 import 'package:mocktail/mocktail.dart';
 
 import '../../helpers/helpers.dart';


### PR DESCRIPTION
## Description

Changes:
- Adds `empty` status
- Adds `WordUnselected` event

## Screenshots/Video
Not applicable, no visual change.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
<!--- Input the Monday.com Item IDs for features addressed in the PR -->
