### PR TITLE
feat: hook WordSelectionBloc selection events

### DIFF
--- a/lib/crossword/game/section_component/section_component.dart
+++ b/lib/crossword/game/section_component/section_component.dart
@@ -14,6 +14,7 @@ import 'package:io_crossword/crossword/extensions/extensions.dart';
 import 'package:io_crossword/crossword/game/section_component/models/models.dart';
 import 'package:io_crossword/word_selection/word_selection.dart'
     show WordSelectionLargeContainer;
+import 'package:io_crossword/word_selection/word_selection.dart' as selection;
 
 part 'section_debug.dart';
 part 'section_keyboard_handler.dart';

--- a/lib/crossword/game/section_component/section_tap_controller.dart
+++ b/lib/crossword/game/section_component/section_tap_controller.dart
@@ -30,6 +30,10 @@ class SectionTapController extends PositionComponent
 
         if (wordRect.contains(localPosition.toOffset())) {
           gameRef.crosswordBloc.add(WordSelected(parent.index, word));
+          gameRef.wordSelectionBloc.add(
+            selection.WordSelected(wordIdentifier: word.id),
+          );
+
           final viewportWidth = gameRef.camera.visibleWorldRect.size.width;
           final newCameraPosition = gameRef.isMobile
               ? Vector2(

--- a/lib/word_selection/view/word_success_view.dart
+++ b/lib/word_selection/view/word_success_view.dart
@@ -8,6 +8,7 @@ import 'package:io_crossword/l10n/l10n.dart';
 import 'package:io_crossword/welcome/welcome.dart';
 import 'package:io_crossword/word_selection/word_selection.dart'
     hide WordUnselected;
+import 'package:io_crossword/word_selection/word_selection.dart' as selection;
 import 'package:io_crossword_ui/io_crossword_ui.dart';
 
 /// {@template word_success_view}
@@ -300,6 +301,7 @@ class KeepPlayingButton extends StatelessWidget {
     return OutlinedButton.icon(
       onPressed: () {
         context.read<CrosswordBloc>().add(const WordUnselected());
+        context.read<WordSelectionBloc>().add(const selection.WordUnselected());
       },
       icon: const Icon(
         Icons.gamepad,

--- a/lib/word_selection/widgets/close_word_selection_icon_button.dart
+++ b/lib/word_selection/widgets/close_word_selection_icon_button.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:io_crossword/crossword/crossword.dart';
+import 'package:io_crossword/word_selection/word_selection.dart'
+    hide WordUnselected;
+import 'package:io_crossword/word_selection/word_selection.dart' as selection;
 import 'package:io_crossword_ui/io_crossword_ui.dart';
 
 /// {@template close_word_selection_icon_button}
@@ -15,6 +18,7 @@ class CloseWordSelectionIconButton extends StatelessWidget {
 
   void _onClose(BuildContext context) {
     context.read<CrosswordBloc>().add(const WordUnselected());
+    context.read<WordSelectionBloc>().add(const selection.WordUnselected());
   }
 
   @override

--- a/test/word_focused/view/word_success_view_test.dart
+++ b/test/word_focused/view/word_success_view_test.dart
@@ -9,6 +9,7 @@ import 'package:io_crossword/crossword/crossword.dart';
 import 'package:io_crossword/l10n/l10n.dart';
 import 'package:io_crossword/word_selection/word_selection.dart'
     hide WordUnselected;
+import 'package:io_crossword/word_selection/word_selection.dart' as selection;
 import 'package:io_crossword_ui/io_crossword_ui.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -18,6 +19,10 @@ import '../../helpers/helpers.dart';
 
 class _MockCrosswordBloc extends MockBloc<CrosswordEvent, CrosswordState>
     implements CrosswordBloc {}
+
+class _MockWordSelectionBloc
+    extends MockBloc<WordSelectionEvent, WordSelectionState>
+    implements WordSelectionBloc {}
 
 class _MockUrlLauncherPlatform extends Mock
     with MockPlatformInterfaceMixin
@@ -189,9 +194,11 @@ void main() {
 
   group('KeepPlayingButton', () {
     late CrosswordBloc crosswordBloc;
+    late WordSelectionBloc wordSelectionBloc;
     late Widget widget;
 
     setUp(() {
+      wordSelectionBloc = _MockWordSelectionBloc();
       crosswordBloc = _MockCrosswordBloc();
       widget = BlocProvider.value(
         value: crosswordBloc,
@@ -202,11 +209,18 @@ void main() {
     testWidgets(
       'adds $WordUnselected event when tapping the keep playing button',
       (tester) async {
-        await tester.pumpApp(widget);
+        await tester.pumpApp(
+          BlocProvider(
+            create: (_) => wordSelectionBloc,
+            child: widget,
+          ),
+        );
 
         await tester.tap(find.byIcon(Icons.gamepad));
 
         verify(() => crosswordBloc.add(const WordUnselected())).called(1);
+        verify(() => wordSelectionBloc.add(const selection.WordUnselected()))
+            .called(1);
       },
     );
   });

--- a/test/word_selection/widgets/close_word_selection_icon_button_test.dart
+++ b/test/word_selection/widgets/close_word_selection_icon_button_test.dart
@@ -1,8 +1,10 @@
 import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:io_crossword/crossword/crossword.dart';
 import 'package:io_crossword/word_selection/word_selection.dart'
     hide WordUnselected;
+import 'package:io_crossword/word_selection/word_selection.dart' as selection;
 import 'package:mocktail/mocktail.dart';
 
 import '../../helpers/helpers.dart';
@@ -10,12 +12,18 @@ import '../../helpers/helpers.dart';
 class _MockCrosswordBloc extends MockBloc<CrosswordEvent, CrosswordState>
     implements CrosswordBloc {}
 
+class _MockWordSelectionBloc
+    extends MockBloc<WordSelectionEvent, WordSelectionState>
+    implements WordSelectionBloc {}
+
 void main() {
   group('$CloseWordSelectionIconButton', () {
     late CrosswordBloc crosswordBloc;
+    late WordSelectionBloc wordSelectionBloc;
 
     setUp(() {
       crosswordBloc = _MockCrosswordBloc();
+      wordSelectionBloc = _MockWordSelectionBloc();
     });
 
     testWidgets('renders $CloseWordSelectionIconButton', (tester) async {
@@ -27,13 +35,18 @@ void main() {
     testWidgets('emits $WordUnselected when tapped', (tester) async {
       await tester.pumpApp(
         crosswordBloc: crosswordBloc,
-        const CloseWordSelectionIconButton(),
+        BlocProvider(
+          create: (_) => wordSelectionBloc,
+          child: const CloseWordSelectionIconButton(),
+        ),
       );
 
       await tester.tap(find.byType(CloseWordSelectionIconButton));
       await tester.pumpAndSettle();
 
       verify(() => crosswordBloc.add(const WordUnselected())).called(1);
+      verify(() => wordSelectionBloc.add(const selection.WordUnselected()))
+          .called(1);
     });
   });
 }


### PR DESCRIPTION
## Description

Changes:
- Makes sure the WordSelectionBloc's `WordSelected` is called where the CrosswordBloc's `WordSelected` is called
- Makes sure the WordSelectionBloc's `WordUnselected` is called where the CrosswordBloc's `WordUnselected` is called

## Screenshots/Video
Not applicable, no visual change.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
<!--- Input the Monday.com Item IDs for features addressed in the PR -->
