### PR TITLE
feat: skip redundant chunk requests

### DIFF
--- a/lib/crossword/bloc/crossword_bloc.dart
+++ b/lib/crossword/bloc/crossword_bloc.dart
@@ -29,6 +29,9 @@ class CrosswordBloc extends Bloc<CrosswordEvent, CrosswordState> {
     BoardSectionRequested event,
     Emitter<CrosswordState> emit,
   ) async {
+    final wasAlreadyRequested = state.sections.containsKey(event.position);
+    if (wasAlreadyRequested) return;
+
     return emit.forEach(
       _crosswordRepository.watchSectionFromPosition(
         event.position.$1,

--- a/lib/crossword/bloc/crossword_event.dart
+++ b/lib/crossword/bloc/crossword_event.dart
@@ -4,6 +4,15 @@ sealed class CrosswordEvent extends Equatable {
   const CrosswordEvent();
 }
 
+/// Requests a chunk of the board to be loaded.
+///
+/// It keeps listening for changes on the chunk even after it's loaded.
+///
+/// Consecutive requests for the same chunk are ignored, since the chunk
+/// is already loaded and listened to.
+// TODO(any): Consider adding the ability to stop listenting for a chunk,
+// to save resources when the chunk is not longer visible.
+// https://very-good-ventures-team.monday.com/boards/6004820050/pulses/6487173469
 class BoardSectionRequested extends CrosswordEvent {
   const BoardSectionRequested(this.position);
 

--- a/test/crossword/bloc/crossword_bloc_test.dart
+++ b/test/crossword/bloc/crossword_bloc_test.dart
@@ -128,6 +128,35 @@ void main() {
       );
 
       blocTest<CrosswordBloc, CrosswordState>(
+        'does nothing if already requested',
+        build: () => CrosswordBloc(
+          crosswordRepository: crosswordRepository,
+          boardInfoRepository: boardInfoRepository,
+        ),
+        setUp: () {
+          when(
+            () => crosswordRepository.watchSectionFromPosition(1, 1),
+          ).thenAnswer((_) => Stream.value(section));
+        },
+        act: (bloc) => bloc
+          ..add(const BoardSectionRequested((1, 1)))
+          ..add(const BoardSectionRequested((1, 1))),
+        expect: () => <CrosswordState>[
+          CrosswordState(
+            status: CrosswordStatus.success,
+            sectionSize: sectionSize,
+            sections: {
+              (1, 1): section,
+            },
+          ),
+        ],
+        verify: (bloc) {
+          verify(() => crosswordRepository.watchSectionFromPosition(1, 1))
+              .called(1);
+        },
+      );
+
+      blocTest<CrosswordBloc, CrosswordState>(
         'emits [success] and adds new sections '
         'when BoardSectionRequested is added',
         build: () => CrosswordBloc(


### PR DESCRIPTION
## Description

Changes:
- Updates `BoardSectionRequested` to skip redundant chunk requests
- Documents `BoardSectionRequested`

## Screenshots/Video
Not applicable.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
<!--- Input the Monday.com Item IDs for features addressed in the PR -->
