### PR TITLE
feat: position IoWord when solved

### DIFF
--- a/lib/crossword2/view/crossword2_view.dart
+++ b/lib/crossword2/view/crossword2_view.dart
@@ -105,12 +105,13 @@ class _CrosswordStack extends StatelessWidget {
             BlocSelector<WordSelectionBloc, WordSelectionState, SelectedWord?>(
               selector: (state) => state.word,
               builder: (context, selectedWord) {
-                if (selectedWord == null ||
-                    selectedWord.word.solvedTimestamp != null) {
+                if (selectedWord == null) {
                   return const SizedBox.shrink();
                 }
 
                 final word = selectedWord.word;
+                final theme = Theme.of(context);
+
                 return Positioned(
                   left: (selectedWord.section.$1 *
                           crosswordLayout.chunkSize.width) +
@@ -120,12 +121,17 @@ class _CrosswordStack extends StatelessWidget {
                           crosswordLayout.chunkSize.height) +
                       (word.position.y * crosswordLayout.cellSize.height) +
                       crosswordLayout.padding.top,
-                  child: CrosswordInput(
-                    key: ValueKey(selectedWord.word.id),
-                    style: Theme.of(context).io.wordInput.secondary,
-                    direction: word.axis.toAxis(),
-                    length: selectedWord.word.length,
-                  ),
+                  child: selectedWord.word.isSolved
+                      ? IoWord(
+                          selectedWord.word.answer,
+                          style: theme.io.wordTheme.big,
+                        )
+                      : CrosswordInput(
+                          key: ValueKey(selectedWord.word.id),
+                          style: theme.io.wordInput.secondary,
+                          direction: word.axis.toAxis(),
+                          length: selectedWord.word.length,
+                        ),
                 );
               },
             ),

--- a/test/crossword2/view/crossword2_view_test.dart
+++ b/test/crossword2/view/crossword2_view_test.dart
@@ -37,6 +37,9 @@ void main() {
       when(() => word.axis).thenReturn(domain.Axis.horizontal);
       when(() => word.position).thenReturn(const Point(0, 0));
       when(() => word.id).thenReturn('id');
+      when(() => word.answer).thenReturn('word');
+      when(() => word.isSolved).thenReturn(false);
+      when(() => word.solvedTimestamp).thenReturn(null);
     });
 
     testWidgets('requests chunk', (tester) async {
@@ -70,6 +73,8 @@ void main() {
       group('shown', () {
         testWidgets('when an unsolved word is selected', (tester) async {
           when(() => word.solvedTimestamp).thenReturn(null);
+          when(() => word.isSolved).thenReturn(false);
+
           when(() => wordSelectionBloc.state).thenReturn(
             WordSelectionState(
               status: WordSelectionStatus.preSolving,
@@ -95,6 +100,8 @@ void main() {
 
         testWidgets('when a solved word is selected', (tester) async {
           when(() => word.solvedTimestamp).thenReturn(1);
+          when(() => word.isSolved).thenReturn(true);
+
           when(() => wordSelectionBloc.state).thenReturn(
             WordSelectionState(
               status: WordSelectionStatus.preSolving,
@@ -200,6 +207,9 @@ void main() {
         testWidgets(
           'horizontally when an horizontal word is to be solved',
           (tester) async {
+            when(() => word.isSolved).thenReturn(false);
+            when(() => word.axis).thenReturn(domain.Axis.horizontal);
+
             when(() => wordSelectionBloc.state).thenReturn(
               WordSelectionState(
                 status: WordSelectionStatus.preSolving,
@@ -231,38 +241,9 @@ void main() {
         testWidgets(
           'vertically when a vertical word is to be solved',
           (tester) async {
-            when(() => wordSelectionBloc.state).thenReturn(
-              WordSelectionState(
-                status: WordSelectionStatus.preSolving,
-                word: SelectedWord(
-                  section: (0, 0),
-                  word: word,
-                ),
-              ),
-            );
-
-            await tester.pumpApp(
-              layout: IoLayoutData.large,
-              DefaultWordInputController(
-                child: BlocProvider<WordSelectionBloc>(
-                  create: (_) => wordSelectionBloc,
-                  child: const Crossword2View(),
-                ),
-              ),
-            );
-
-            final wordInputFinder = find.byType(IoWordInput);
-            expect(wordInputFinder, findsOneWidget);
-
-            final wordInput = tester.widget<IoWordInput>(wordInputFinder);
-            expect(wordInput.direction, equals(Axis.horizontal));
-          },
-        );
-
-        testWidgets(
-          'horizontally when a word is to be solved',
-          (tester) async {
+            when(() => word.isSolved).thenReturn(false);
             when(() => word.axis).thenReturn(domain.Axis.vertical);
+
             when(() => wordSelectionBloc.state).thenReturn(
               WordSelectionState(
                 status: WordSelectionStatus.preSolving,
@@ -296,6 +277,8 @@ void main() {
         testWidgets(
           'when word is not solved with a small layout',
           (tester) async {
+            when(() => word.isSolved).thenReturn(false);
+
             when(() => wordSelectionBloc.state).thenReturn(
               WordSelectionState(
                 status: WordSelectionStatus.preSolving,
@@ -321,6 +304,8 @@ void main() {
         testWidgets(
           'when word is solved',
           (tester) async {
+            when(() => word.isSolved).thenReturn(true);
+
             when(() => word.solvedTimestamp).thenReturn(1);
             when(() => wordSelectionBloc.state).thenReturn(
               WordSelectionState(
@@ -367,6 +352,70 @@ void main() {
           },
         );
       });
+    });
+
+    group('$IoWord', () {
+      testWidgets(
+        'shown with answer when word is solved',
+        (tester) async {
+          when(() => word.isSolved).thenReturn(true);
+
+          when(() => word.solvedTimestamp).thenReturn(1);
+          when(() => wordSelectionBloc.state).thenReturn(
+            WordSelectionState(
+              status: WordSelectionStatus.preSolving,
+              word: SelectedWord(
+                section: (0, 0),
+                word: word,
+              ),
+            ),
+          );
+
+          await tester.pumpApp(
+            layout: IoLayoutData.large,
+            BlocProvider<WordSelectionBloc>(
+              create: (_) => wordSelectionBloc,
+              child: const Crossword2View(),
+            ),
+          );
+
+          final ioWordFinder = find.byType(IoWord);
+          expect(ioWordFinder, findsOneWidget);
+
+          final ioWord = tester.widget<IoWord>(ioWordFinder);
+          expect(ioWord.data, equals(word.answer));
+        },
+      );
+
+      testWidgets(
+        'not shown when word is not solved',
+        (tester) async {
+          when(() => word.isSolved).thenReturn(false);
+
+          when(() => word.solvedTimestamp).thenReturn(1);
+          when(() => wordSelectionBloc.state).thenReturn(
+            WordSelectionState(
+              status: WordSelectionStatus.preSolving,
+              word: SelectedWord(
+                section: (0, 0),
+                word: word,
+              ),
+            ),
+          );
+
+          await tester.pumpApp(
+            layout: IoLayoutData.large,
+            DefaultWordInputController(
+              child: BlocProvider<WordSelectionBloc>(
+                create: (_) => wordSelectionBloc,
+                child: const Crossword2View(),
+              ),
+            ),
+          );
+
+          expect(find.byType(IoWord), findsNothing);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

Changes:
- Overlays `IoWord` when selected a solved word.

> Note: the actual styling to be tackled on a follow-up PR.

## Screenshots/Video

![CleanShot 2024-04-26 at 13 21 39](https://github.com/VGVentures/io_crossword/assets/44524995/630ea8b9-1f7b-4068-a7d4-73ef31a143bf)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
<!--- Input the Monday.com Item IDs for features addressed in the PR -->
