### PR TITLE
feat: show backdrop on small layouts

### DIFF
--- a/lib/crossword2/view/crossword2_view.dart
+++ b/lib/crossword2/view/crossword2_view.dart
@@ -92,15 +92,14 @@ class _CrosswordStack extends StatelessWidget {
                   crosswordLayout.padding.top,
               child: CrosswordChunk(index: chunk),
             ),
-          if (layout == IoLayoutData.large)
-            BlocSelector<WordSelectionBloc, WordSelectionState, SelectedWord?>(
-              selector: (state) => state.word,
-              builder: (context, selectedWord) {
-                return selectedWord != null
-                    ? const CrosswordBackdrop()
-                    : const SizedBox.shrink();
-              },
-            ),
+          BlocSelector<WordSelectionBloc, WordSelectionState, SelectedWord?>(
+            selector: (state) => state.word,
+            builder: (context, selectedWord) {
+              return selectedWord != null
+                  ? const CrosswordBackdrop()
+                  : const SizedBox.shrink();
+            },
+          ),
           if (layout == IoLayoutData.large)
             BlocSelector<WordSelectionBloc, WordSelectionState, SelectedWord?>(
               selector: (state) => state.word,

--- a/test/crossword2/view/crossword2_view_test.dart
+++ b/test/crossword2/view/crossword2_view_test.dart
@@ -122,9 +122,7 @@ void main() {
 
           expect(find.byType(CrosswordBackdrop), findsOneWidget);
         });
-      });
 
-      group('not shown', () {
         testWidgets(
           'when a solved word is selected with a small layout',
           (tester) async {
@@ -147,7 +145,7 @@ void main() {
               ),
             );
 
-            expect(find.byType(CrosswordBackdrop), findsNothing);
+            expect(find.byType(CrosswordBackdrop), findsOneWidget);
           },
         );
 
@@ -173,10 +171,12 @@ void main() {
               ),
             );
 
-            expect(find.byType(CrosswordBackdrop), findsNothing);
+            expect(find.byType(CrosswordBackdrop), findsOneWidget);
           },
         );
+      });
 
+      group('not shown', () {
         testWidgets(
           'when no word is selected with a large layout',
           (tester) async {
@@ -190,6 +190,29 @@ void main() {
 
             await tester.pumpApp(
               layout: IoLayoutData.large,
+              BlocProvider<WordSelectionBloc>(
+                create: (_) => wordSelectionBloc,
+                child: const Crossword2View(),
+              ),
+            );
+
+            expect(find.byType(CrosswordBackdrop), findsNothing);
+          },
+        );
+
+        testWidgets(
+          'when no word is selected with a small layout',
+          (tester) async {
+            when(() => wordSelectionBloc.state).thenReturn(
+              const WordSelectionState(
+                status: WordSelectionStatus.empty,
+                // ignore: avoid_redundant_argument_values
+                word: null,
+              ),
+            );
+
+            await tester.pumpApp(
+              layout: IoLayoutData.small,
               BlocProvider<WordSelectionBloc>(
                 create: (_) => wordSelectionBloc,
                 child: const Crossword2View(),


### PR DESCRIPTION
## Description

As per the design specification: the black backdrop, should be shown in mobile.

Changes:
- Show backdrop when word is selected on small layouts


> Note, the overlay of the selected word in a small layout is being worked on in a separate item.

## Screenshots/Video

![CleanShot 2024-04-29 at 10 38 37](https://github.com/VGVentures/io_crossword/assets/44524995/6a049534-fcf5-4717-b259-c905b38ecdee)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
6539804720
