### PR TITLE
refactor: use wordRect to compute center

### DIFF
--- a/lib/crossword2/widgets/crossword_interactive_viewer.dart
+++ b/lib/crossword2/widgets/crossword_interactive_viewer.dart
@@ -89,7 +89,7 @@ class _CrosswordInteractiveViewerState extends State<CrosswordInteractiveViewer>
 
     final wordRect = selectedWord.offset(crosswordLayout) &
         selectedWord.word.size(crosswordLayout);
-    final wordMiddle = wordRect.center;
+    final wordCenter = wordRect.center;
 
     final begin = _transformationController.value.getTranslation();
 
@@ -100,7 +100,7 @@ class _CrosswordInteractiveViewerState extends State<CrosswordInteractiveViewer>
       reducedViewportSize.height / 2,
       0,
     );
-    final end = center - Vector3(wordMiddle.dx, wordMiddle.dy, 0);
+    final end = center - Vector3(wordCenter.dx, wordCenter.dy, 0);
     end
       ..x = math.max(
         math.min(end.x, _minTranslation.x),


### PR DESCRIPTION
## Description

Refactors and simplifies logic by relying on `Rect` and `Size` to compute the middle point of the word.

The `Rect` and `Size` will later on be useful to resolve [6583393011](https://very-good-ventures-team.monday.com/boards/6004820050/pulses/6583393011).

## Screenshots/Video
No visual change.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
6583548968