### PR TITLE
fix: adds color on typing for desktop

### DIFF
--- a/packages/io_crossword_ui/lib/src/theme/io_crossword_theme.dart
+++ b/packages/io_crossword_ui/lib/src/theme/io_crossword_theme.dart
@@ -138,9 +138,9 @@ class IoCrosswordTheme {
           size: size,
         ),
         filled: IoWordInputCharacterFieldStyle(
-          backgroundColor: backgroundColor,
+          backgroundColor: colorScheme.primary,
           border: Border.all(
-            color: borderSide.color,
+            color: colorScheme.primary,
             width: borderSide.width,
           ),
           borderRadius: BorderRadius.zero,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
In this PR we are adding the color when typing a word in desktop.
## Screenshots/Video
<!--- Add a screenshot or a video showcasing the changes -->
| vertical | horizontal |
| --- | --- |
| ![Screenshot 2024-05-06 at 13 55 10](https://github.com/VGVentures/io_crossword/assets/42848220/e62d7317-09e0-4830-ae78-3d1397c20a53) | ![Screenshot 2024-05-06 at 13 55 44](https://github.com/VGVentures/io_crossword/assets/42848220/57c59129-c6a8-4eee-aaca-23bbfa6da4b4) |

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
<!--- Input the Monday.com Item IDs for features addressed in the PR -->
[6574149416](https://very-good-ventures-team.monday.com/boards/6004820050/pulses/6574149416)