### PR TITLE
feat: remove 1000 player label

### DIFF
--- a/lib/team_selection/view/team_selection_page.dart
+++ b/lib/team_selection/view/team_selection_page.dart
@@ -445,13 +445,7 @@ class _TeamSelector extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 8),
-        // TODO(marwfair): Get the team player count.
-        // https://very-good-ventures-team.monday.com/boards/6004820050/pulses/6422631645
-        const Text('10000 players'),
-        const SizedBox(
-          height: 32,
-        ),
+        const SizedBox(height: 32),
         _SubmitButton(Mascots.values[index]),
       ],
     );


### PR DESCRIPTION
## Description

Removes the 1000 player label on the team selection page.

## Screenshots/Video

https://github.com/VGVentures/io_crossword/assets/44524995/f61e308c-ba28-4209-8c19-15edcc8b6159


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
[6581814840](https://very-good-ventures-team.monday.com/boards/6004820050/pulses/6581814840)
