### PR TITLE
fix: remove play again button from the leaderboard page

### DIFF
--- a/lib/leaderboard/view/leaderboard_page.dart
+++ b/lib/leaderboard/view/leaderboard_page.dart
@@ -49,24 +49,7 @@ class LeaderboardView extends StatelessWidget {
         title: Text(l10n.leaderboard),
         crossword: l10n.crossword,
         actions: (context) {
-          final layout = IoLayout.of(context);
-
-          return switch (layout) {
-            IoLayoutData.small => const CloseButton(),
-            IoLayoutData.large => Row(
-                children: [
-                  OutlinedButton.icon(
-                    onPressed: () {
-                      Navigator.pop(context);
-                    },
-                    icon: const Icon(Icons.gamepad),
-                    label: Text(l10n.playAgain),
-                  ),
-                  const SizedBox(width: 7),
-                  const CloseButton(),
-                ],
-              ),
-          };
+          return const CloseButton();
         },
       ),
       body: BlocBuilder<LeaderboardBloc, LeaderboardState>(

--- a/test/leaderboard/view/leaderboard_page_test.dart
+++ b/test/leaderboard/view/leaderboard_page_test.dart
@@ -122,53 +122,5 @@ void main() {
         expect(find.byType(LeaderboardSuccess), findsOneWidget);
       },
     );
-
-    testWidgets(
-      'does not display playAgain and icon on small screen',
-      (tester) async {
-        when(() => leaderboardBloc.state).thenReturn(LeaderboardState());
-
-        await tester.pumpApp(widget);
-
-        expect(find.text(l10n.playAgain), findsNothing);
-        expect(find.byIcon(Icons.gamepad), findsNothing);
-      },
-    );
-
-    testWidgets(
-      'display playAgain and icon on large screen',
-      (tester) async {
-        when(() => leaderboardBloc.state).thenReturn(LeaderboardState());
-
-        await tester.pumpApp(
-          widget,
-          layout: IoLayoutData.large,
-        );
-
-        expect(find.text(l10n.playAgain), findsOneWidget);
-        expect(find.byIcon(Icons.gamepad), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'pops the screen when playAgain is tapped',
-      (tester) async {
-        final mockNavigator = MockNavigator();
-
-        when(mockNavigator.canPop).thenReturn(true);
-
-        when(() => leaderboardBloc.state).thenReturn(LeaderboardState());
-
-        await tester.pumpApp(
-          widget,
-          navigator: mockNavigator,
-          layout: IoLayoutData.large,
-        );
-
-        await tester.tap(find.text(l10n.playAgain));
-
-        verify(mockNavigator.pop).called(1);
-      },
-    );
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
In this PR we removing play again button from the leaderboard page.
## Screenshots/Video
<!--- Add a screenshot or a video showcasing the changes -->
| Mobile | Desktop |
| --- | --- |
| ![Screenshot 2024-05-10 at 16 30 19](https://github.com/VGVentures/io_crossword/assets/42848220/b6e80d3e-bfb9-4a99-828d-6ca0b4965698) | ![Screenshot 2024-05-10 at 16 30 28](https://github.com/VGVentures/io_crossword/assets/42848220/fb1653ef-ba9d-446d-bc3e-eec456f67d93) |

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
<!--- Input the Monday.com Item IDs for features addressed in the PR -->
[6581816758](https://very-good-ventures-team.monday.com/boards/6004820050/pulses/6581816758)