### PR TITLE
fix: on success displays solved share word dialog

### DIFF
--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -12,6 +12,14 @@
   "@settings": {
     "description": "Settings label"
   },
+  "iSolvedWord": "I solved a word!",
+  "@iSolvedWord": {
+    "description": "I solved a word displayed on solved shared word"
+  },
+  "joinToSolveBoard": "Join me on I/O Crossword and help us solve the full board together!",
+  "@joinToSolveBoard": {
+    "description": "Description displayed on solved shared word"
+  },
   "shareThisWord": "Share this word",
   "@shareThisWord": {
     "description": "Share this word label"

--- a/lib/share/view/share_solved_word_page.dart
+++ b/lib/share/view/share_solved_word_page.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:game_domain/game_domain.dart' show Word;
+import 'package:io_crossword/l10n/l10n.dart';
+import 'package:io_crossword/project_details/project_details.dart';
+import 'package:io_crossword/share/share.dart';
+import 'package:io_crossword/word_selection/word_selection.dart';
+import 'package:io_crossword_ui/io_crossword_ui.dart';
+
+class ShareSolvedWordPage extends StatelessWidget {
+  const ShareSolvedWordPage({
+    required this.word,
+    super.key,
+  });
+
+  final Word word;
+
+  static Future<void> showModal(BuildContext context) async {
+    final word = context.read<WordSelectionBloc>().state.word;
+    final l10n = context.l10n;
+
+    // If there are no words selected will display error message.
+    if (word == null) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text(l10n.errorPromptText),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      return;
+    }
+
+    return showDialog<void>(
+      context: context,
+      builder: (context) {
+        final l10n = context.l10n;
+
+        return ShareDialog(
+          title: l10n.shareThisWord,
+          content: ShareSolvedWordPage(
+            word: word.word,
+          ),
+          url: ProjectDetailsLinks.crossword,
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final themeData = Theme.of(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        Text(
+          l10n.iSolvedWord,
+          textAlign: TextAlign.center,
+          style: themeData.textTheme.bodyLarge.regular,
+        ),
+        const SizedBox(height: IoCrosswordSpacing.xlgsm),
+        Text(
+          l10n.joinToSolveBoard,
+          textAlign: TextAlign.center,
+          style: themeData.textTheme.bodyLarge.regular,
+        ),
+        const SizedBox(height: IoCrosswordSpacing.xxlg),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: IoWord(
+            word.answer,
+            style: themeData.io.wordTheme.big,
+          ),
+        ),
+        const SizedBox(height: IoCrosswordSpacing.xlg),
+        Text(
+          word.clue,
+          style: themeData.textTheme.bodyLarge.regular
+              ?.copyWith(color: themeData.colorScheme.primary),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/share/view/view.dart
+++ b/lib/share/view/view.dart
@@ -1,2 +1,3 @@
 export 'share_score_page.dart';
+export 'share_solved_word_page.dart';
 export 'share_word_page.dart';

--- a/lib/word_selection/view/word_success_view.dart
+++ b/lib/word_selection/view/word_success_view.dart
@@ -186,7 +186,7 @@ class SuccessTopBar extends StatelessWidget {
       children: [
         IconButton(
           onPressed: () {
-            ShareWordPage.showModal(context);
+            ShareSolvedWordPage.showModal(context);
           },
           icon: const Icon(Icons.ios_share),
           style: themeData.io.iconButtonTheme.filled,

--- a/test/share/view/share_word_solved_page_test.dart
+++ b/test/share/view/share_word_solved_page_test.dart
@@ -1,0 +1,224 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:game_domain/game_domain.dart';
+import 'package:io_crossword/l10n/l10n.dart';
+import 'package:io_crossword/project_details/project_details.dart';
+import 'package:io_crossword/share/share.dart';
+import 'package:io_crossword/word_selection/word_selection.dart';
+import 'package:io_crossword_ui/io_crossword_ui.dart';
+import 'package:mockingjay/mockingjay.dart';
+
+import '../../helpers/helpers.dart';
+
+class _FakeWord extends Fake implements Word {
+  @override
+  String get answer => 'answer';
+
+  @override
+  String get clue => 'clue';
+
+  @override
+  int get length => 5;
+}
+
+class _MockWordSelectionBloc
+    extends MockBloc<WordSelectionEvent, WordSelectionState>
+    implements WordSelectionBloc {}
+
+void main() {
+  group('$ShareSolvedWordPage', () {
+    late AppLocalizations l10n;
+
+    setUpAll(() async {
+      l10n = await AppLocalizations.delegate.load(Locale('en'));
+    });
+
+    testWidgets(
+      'renders IoWord',
+      (tester) async {
+        final word = _FakeWord();
+        await tester.pumpApp(
+          ShareSolvedWordPage(word: word),
+        );
+
+        expect(find.byType(IoWord), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'displays the answer correctly in IoWord',
+      (tester) async {
+        final word = _FakeWord();
+        await tester.pumpApp(
+          ShareSolvedWordPage(word: word),
+        );
+
+        expect(
+          tester.widget<IoWord>(find.byType(IoWord)).data,
+          equals('answer'),
+        );
+      },
+    );
+
+    testWidgets(
+      'displays iSolvedWord',
+      (tester) async {
+        final word = _FakeWord();
+        await tester.pumpApp(
+          ShareSolvedWordPage(word: word),
+        );
+
+        expect(find.text(l10n.iSolvedWord), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'displays joinToSolveBoard',
+      (tester) async {
+        final word = _FakeWord();
+        await tester.pumpApp(
+          ShareSolvedWordPage(word: word),
+        );
+
+        expect(find.text(l10n.joinToSolveBoard), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'displays clue',
+      (tester) async {
+        final word = _FakeWord();
+        await tester.pumpApp(
+          ShareSolvedWordPage(word: word),
+        );
+
+        expect(find.text(word.clue), findsOneWidget);
+      },
+    );
+
+    group('showModal', () {
+      late WordSelectionBloc wordSelectionBloc;
+
+      setUp(() {
+        wordSelectionBloc = _MockWordSelectionBloc();
+      });
+
+      testWidgets(
+        'opens the $ShareSolvedWordPage in a $ShareDialog when there is a word',
+        (tester) async {
+          when(() => wordSelectionBloc.state).thenReturn(
+            WordSelectionState(
+              status: WordSelectionStatus.preSolving,
+              word: SelectedWord(
+                word: _FakeWord(),
+                section: (0, 0),
+              ),
+            ),
+          );
+
+          await tester.pumpApp(
+            BlocProvider<WordSelectionBloc>(
+              create: (context) => wordSelectionBloc,
+              child: Scaffold(
+                body: Builder(
+                  builder: (BuildContext context) {
+                    return ElevatedButton(
+                      onPressed: () => ShareSolvedWordPage.showModal(context),
+                      child: Text('Show ShareSolvedWordPage'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.byType(ElevatedButton));
+          await tester.pumpAndSettle();
+
+          expect(find.byType(ShareDialog), findsOneWidget);
+          expect(find.byType(ShareSolvedWordPage), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Displays $SnackBar error when there is a word',
+        (tester) async {
+          late AppLocalizations l10n;
+
+          when(() => wordSelectionBloc.state).thenReturn(
+            WordSelectionState(
+              status: WordSelectionStatus.preSolving,
+            ),
+          );
+
+          await tester.pumpApp(
+            BlocProvider<WordSelectionBloc>(
+              create: (context) => wordSelectionBloc,
+              child: Scaffold(
+                body: Builder(
+                  builder: (BuildContext context) {
+                    l10n = context.l10n;
+
+                    return ElevatedButton(
+                      onPressed: () => ShareSolvedWordPage.showModal(context),
+                      child: Text('Show ShareSolvedWordPage'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.byType(ElevatedButton));
+          await tester.pumpAndSettle();
+
+          expect(find.byType(SnackBar), findsOneWidget);
+          expect(find.text(l10n.errorPromptText), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'uses correct facebook url',
+        (tester) async {
+          when(() => wordSelectionBloc.state).thenReturn(
+            WordSelectionState(
+              status: WordSelectionStatus.preSolving,
+              word: SelectedWord(
+                word: _FakeWord(),
+                section: (0, 0),
+              ),
+            ),
+          );
+
+          await tester.pumpApp(
+            BlocProvider<WordSelectionBloc>(
+              create: (context) => wordSelectionBloc,
+              child: Scaffold(
+                body: Builder(
+                  builder: (BuildContext context) {
+                    return ElevatedButton(
+                      onPressed: () => ShareSolvedWordPage.showModal(context),
+                      child: Text('open share score'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.byType(ElevatedButton));
+          await tester.pumpAndSettle();
+
+          expect(
+            tester.widget<ShareDialog>(find.byType(ShareDialog)).url,
+            equals(ProjectDetailsLinks.crossword),
+          );
+        },
+      );
+    });
+  });
+}

--- a/test/word_focused/view/word_success_view_test.dart
+++ b/test/word_focused/view/word_success_view_test.dart
@@ -285,7 +285,7 @@ void main() {
     );
 
     testWidgets(
-      'renders ShareWordPage when icon ios_share tapped',
+      'renders ShareSolvedWordPage when icon ios_share tapped',
       (tester) async {
         when(() => wordSelectionBloc.state).thenReturn(
           WordSelectionState(
@@ -300,7 +300,7 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        expect(find.byType(ShareWordPage), findsOneWidget);
+        expect(find.byType(ShareSolvedWordPage), findsOneWidget);
       },
     );
   });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
In this PR we are showing the solved word dialog on success.
## Screenshots/Video
<!--- Add a screenshot or a video showcasing the changes -->

https://github.com/VGVentures/io_crossword/assets/42848220/f58cbb12-b651-4ef1-80af-60053214e0c5


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
<!--- Input the Monday.com Item IDs for features addressed in the PR -->
[6551766396](https://very-good-ventures-team.monday.com/boards/6004820050/pulses/6551766396)
