### PR TITLE
fix: leaderboard You text color and initial aligned

### DIFF
--- a/lib/leaderboard/view/leaderboard_success.dart
+++ b/lib/leaderboard/view/leaderboard_success.dart
@@ -142,9 +142,8 @@ class CurrentUserPosition extends StatelessWidget {
             children: [
               Text(
                 '${l10n.you}:',
-                style: theme.io.textStyles.body4.copyWith(
+                style: theme.io.textStyles.body4.medium?.copyWith(
                   color: IoCrosswordColors.softGray,
-                  fontWeight: FontWeight.w500,
                 ),
               ),
               UserLeaderboardRanking(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
In this PR we are fixing the leaderboard `You` text color and aligning the initials.
## Screenshots/Video
<!--- Add a screenshot or a video showcasing the changes -->
![Screenshot 2024-05-21 at 17 14 42](https://github.com/VGVentures/io_crossword/assets/42848220/7aa57b6a-8517-4b38-b8bd-ccf810a639dd)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Monday.com Item IDs
<!--- Input the Monday.com Item IDs for features addressed in the PR -->
[6472143133](https://very-good-ventures-team.monday.com/boards/6004820050/pulses/6472143133)