### PR TITLE
fix: play sound effects first thing in onPressed methods

### DIFF
--- a/lib/how_to_play/view/how_to_play_page.dart
+++ b/lib/how_to_play/view/how_to_play_page.dart
@@ -112,11 +112,11 @@ class _HowToPlaySmall extends StatelessWidget {
                           mascot: mascot,
                           onDonePressed: () {
                             context
-                                .read<HowToPlayCubit>()
-                                .updateStatus(HowToPlayStatus.pickingUp);
-                            context
                                 .read<AudioController>()
                                 .playSfx(Assets.music.startButton1);
+                            context
+                                .read<HowToPlayCubit>()
+                                .updateStatus(HowToPlayStatus.pickingUp);
                           },
                         ),
                       ),
@@ -176,11 +176,11 @@ class _HowToPlayLarge extends StatelessWidget {
                         mascot: mascot,
                         onDonePressed: () {
                           context
-                              .read<HowToPlayCubit>()
-                              .updateStatus(HowToPlayStatus.pickingUp);
-                          context
                               .read<AudioController>()
                               .playSfx(Assets.music.startButton1);
+                          context
+                              .read<HowToPlayCubit>()
+                              .updateStatus(HowToPlayStatus.pickingUp);
                         },
                       ),
                       const SizedBox(height: 40),

--- a/lib/how_to_play/widgets/play_now_button.dart
+++ b/lib/how_to_play/widgets/play_now_button.dart
@@ -10,9 +10,9 @@ class PlayNowButton extends StatelessWidget {
   const PlayNowButton({super.key});
 
   void _onPressed(BuildContext context) {
+    context.read<AudioController>().playSfx(Assets.music.startButton1);
     context.read<PlayerBloc>().add(const PlayerCreateScoreRequested());
     context.read<HowToPlayCubit>().updateStatus(HowToPlayStatus.pickingUp);
-    context.read<AudioController>().playSfx(Assets.music.startButton1);
   }
 
   @override

--- a/lib/initials/view/initials_page.dart
+++ b/lib/initials/view/initials_page.dart
@@ -113,10 +113,10 @@ class _InitialsViewState extends State<InitialsView> {
                     ),
                     InitialsSubmitButton(
                       onPressed: () {
-                        _onSubmit(context);
                         context
                             .read<AudioController>()
                             .playSfx(Assets.music.startButton1);
+                        _onSubmit(context);
                       },
                     ),
                   ],


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
Play sound effects first thing in the onTap methods to avoid having lag on playing the sounds

## Screenshots/Video
<!--- Add a screenshot or a video showcasing the changes -->
Not applicable

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
