### PR TITLE
fix: use correct longest and shortest words when generating asymmetrical board

### DIFF
--- a/packages/board_generator_playground/lib/scripts/asymmetrical_generation.dart
+++ b/packages/board_generator_playground/lib/scripts/asymmetrical_generation.dart
@@ -24,7 +24,11 @@ void main({void Function(String) log = print}) {
 
   final generator = AsymmetricalCrosswordGenerator(
     pool: wordPool,
-    crossword: Crossword(bounds: Bounds.square(size: 78)),
+    crossword: Crossword(
+      bounds: Bounds.square(size: 78),
+      largestWordLength: wordPool.longestWordLength,
+      shortestWordLength: wordPool.shortestWordLength,
+    ),
   );
 
   final crossword = generator.populate();
@@ -49,7 +53,7 @@ void main({void Function(String) log = print}) {
 
   final notUsedWords = wordsList.where((w) => !wordsString.contains(w.word));
 
-  log('Unused words: ${notUsedWords.length}');
+  log('Unused words: ${notUsedWords.map((w) => w.word).toList()}');
 
   File('board_asymmetrical.txt')
       .writeAsStringSync(const ListToCsvConverter().convert(list));

--- a/packages/board_generator_playground/lib/src/generators/asymmetrical_crossword_generator.dart
+++ b/packages/board_generator_playground/lib/src/generators/asymmetrical_crossword_generator.dart
@@ -31,7 +31,7 @@ class AsymmetricalCrosswordGenerator extends CrosswordGenerator {
       invalidLengths: {},
       start: Location.zero,
       direction: Direction.across,
-      constraints: {0: 'a'},
+      constraints: {0: 'e'},
     );
     final word = pool.firstMatch(constraints)!;
     final entry = WordEntry(

--- a/packages/board_uploader/lib/src/crossword_repository.dart
+++ b/packages/board_uploader/lib/src/crossword_repository.dart
@@ -14,7 +14,7 @@ class CrosswordRepository {
 
   /// Adds a map of word id: answer to the database.
   Future<void> addAnswers(List<Answer> answers) async {
-    const size = 100;
+    const size = 10;
     final maps = answers.slices(size);
 
     await Future.wait(maps.map(_addAnswers));
@@ -29,7 +29,7 @@ class CrosswordRepository {
 
   /// Adds a list of sections to the database.
   Future<void> addSections(List<BoardSection> sections) async {
-    const size = 50;
+    const size = 1;
     final maps = sections.slices(size);
 
     await Future.wait(maps.map(_addSections));


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
Pass longest and shortest word lengths when generating an asymmetrical crossword to calculate correct constraints

## Screenshots/Video
<!--- Add a screenshot or a video showcasing the changes -->
Not applicable

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
